### PR TITLE
add `act` field to share request

### DIFF
--- a/messages/sharereq.md
+++ b/messages/sharereq.md
@@ -16,7 +16,7 @@ Name | Description | Required
 [`exp`](https://tools.ietf.org/html/rfc7519#section-4.1.4) | Expiration time of JWT | no
 `callback` | Callback URL for returning the response to a request | no
 `net` | network id of Ethereum chain of identity eg. `0x4` for `rinkeby` | no
-`act` | Ethereum account type: `general` users choice (default), `segregated` a unique account will be created for requesting app, `none` no account is returned | no
+`act` | Ethereum account type: `general` users choice (default), `segregated` a unique smart contract based account will be created for requesting app, `keypair` a unique keypair based account will be created for requesting app, `none` no account is returned | no
 `requested` | The self signed claims requested from a user. Array of claim types for self signed claims eg: `["name", "email"]` | no
 `verified` | The verified claims requested from a user. Array of claim types for self signed claims eg: `["name", "email"]` | no
 `permissions` | An array of permissions requested. Currently only supported is `notifications` | no

--- a/messages/sharereq.md
+++ b/messages/sharereq.md
@@ -16,6 +16,7 @@ Name | Description | Required
 [`exp`](https://tools.ietf.org/html/rfc7519#section-4.1.4) | Expiration time of JWT | no
 `callback` | Callback URL for returning the response to a request | no
 `net` | network id of Ethereum chain of identity eg. `0x4` for `rinkeby` | no
+`act` | Ethereum account type: `general` users choice (default), `segregated` a unique account will be created for requesting app, `none` no account is returned | no
 `requested` | The self signed claims requested from a user. Array of claim types for self signed claims eg: `["name", "email"]` | no
 `verified` | The verified claims requested from a user. Array of claim types for self signed claims eg: `["name", "email"]` | no
 `permissions` | An array of permissions requested. Currently only supported is `notifications` | no


### PR DESCRIPTION
We would like the requester to specify a kind of ethereum account to be returned.

It introduces an optional `act` field to the shareRequest.

It can contain the following 3 options:

`act` value | Description 
---- | -----------
`general` | users choice (default)
`segregated` | A unique smart contract based account is created  on behalf of the requesting app
`keypair` | A unique key pair based account is created on behalf of the requesting app
`none`| no account is returned. This is useful if your use case does not need ethereum interaction

The reasoning for the `segregated` account is that helps ensure privacy for your users. There is no longer a way to map a users activities across the blockchain.

We may add further options in the future and may make the default `none`