### PR TITLE
add redirect-url param

### DIFF
--- a/flows/selectivedisclosure.md
+++ b/flows/selectivedisclosure.md
@@ -21,6 +21,8 @@ Signed example:
 
 `me.uport:me?requestToken=eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJp...`
 
+The attributes `redirect_url` and `callback_type` can also be appended to the URL as encoded query parameters to specify how you want the response and control returned. For more details see [Messages](./index.md#json-web-token).
+
 Unsigned example:
 
 `me.uport:me?callback_url=https://mysite.com/callback&label=My%20Site`

--- a/flows/verification.md
+++ b/flows/verification.md
@@ -25,6 +25,9 @@ Example:
 
 `me.uport:add?attestations=eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJp...`
 
+The attributes `redirect_url` and `callback_type` can also be appended to the URL as encoded query parameters to specify how you want the response and control returned. For more details see [Messages](./index.md#json-web-token).
+
+
 ## Client Callback
 
 The client app MAY include a URL where the response is returned from the user. This can be a HTTPS URL or a custom app URL which receives the response. The callback is strictly optional and is mainly used if you need to acknowledge in your UX that the attestation has been received.

--- a/messages/index.md
+++ b/messages/index.md
@@ -37,6 +37,15 @@ Name | Description | Required
 `callback` | Callback URL for returning the response to a request | no
 `type` | Type of Message | no
 
+The following attributes can also be appended to the signed request as URL encoded query parameters outside of the signed payload.
+
+Name | Description | Required
+---- | ----------- | --------
+`redirect_url` | The URL that control is returned to once a request is complete (mobile). Base url/domain must match callback in JWT. | no
+`callback_type` | Valid values `post` or `redirect`. Determines if callback should be sent as a HTTP POST or open the link (`redirect`). If unspecified, the mobile app will attempt to pick the correct one| no
+
+These options allow you to tell the client how you want to receive the response. If a redirect_url is provided, the client will post the response to the callback in the JWT and then call the given redirect_url to return control to the original callee. You can also add any contextual data in the redirect_url query params or as a url fragment (i.e. you may want to map requests to responses). If a redirect_url is provided and a callback_type redirect is provided the response will be passed as url fragment with the redirect_url. If no redirect_url is provided, it will use the callback in JWT and will use the callback_type if provided or the client will attempt to choose the correct type.
+
 ### Signature Verification
 
 Each uPort compatible JWT must be signed using an secp256k1 curve. The public key is resolved for the `iss` using the [uPort PKI](../pki/index.md).

--- a/messages/sharereq.md
+++ b/messages/sharereq.md
@@ -20,6 +20,8 @@ Name | Description | Required
 `verified` | The verified claims requested from a user. Array of claim types for self signed claims eg: `["name", "email"]` | no
 `permissions` | An array of permissions requested. Currently only supported is `notifications` | no
 
+The attributes `redirect_url` and `callback_type` can also be appended to the signed request as URL encoded query parameters outside of the signed payload. They are used to specify how you want the response and control returned. For more details see [Messages](./index.md#json-web-token).
+
 ## Unsigned Requests
 
 To perform an unsigned selective disclosure request append the request parameters as URL encoded query parameters to one of the above endpoints and open it. Eg.:


### PR DESCRIPTION
Adding this param increases optionality for developers when choosing how they want to handle responses. It also allows the uport client to make less assumptions about the callee. 

The libraries and uport client will still make default assumptions for default use cases but this allows developers to receive responses how they want and may encourage us to change our defaults if used in ways we did not expected. 

Minimizing assumptions implicit in some of our params allows us to unbundle functionality/dependencies in our libs. Improving front/backend flow and allowing developers to eventually plug in their own modules. 

This is proposed as the most immediate simple solution although there appears to be better overall solutions if we are willing to make other spec changes at the same time. Alternatives to this include: 
 
- with ‘authorized callbacks’, CB could be removed from JWT and we could just have redirect_url and callback_url url params, while one or both could be specified at the same time (they would have to match one of the authorized CBs
-  could specify both redirect_url and callback_url in JWT and allow for callback_type (url param) to specific redirect, post or both (cb & action selected based on that)
- could specify domain/base url in JWT and then allow redirect_url and callback_url url params (which must match base url/domain)

Notes:

- may be nice to allow additional data (params, url fragments) to be added to callbacks outside of CBs specified in signed payloads. Allows app context to be passed like sessions or to map req to responses. Although may allow CSRF attacks and server may be able to add these values if they want in the signed payloads instead still (JWTs) (although a question for authorized callbacks)

- in this quick suggested implementation, the redirect_url should match the base url/domain in the signed payload (JWT) How limiting is this requirement potentially  (mobile app urls + servers?) ?  might be better to just allow both callbacks to separately specified

- WIP since other pages will also be edited once a solution is chosen