### PR TITLE
Create unified endpoint and deprecate old ones

### DIFF
--- a/flows/index.md
+++ b/flows/index.md
@@ -4,6 +4,16 @@ A request will typically be signed by a client app and sent to mobile app using 
 
 ![Generic uPort Request Flow](generic.png)
 
+## Unified Message Request Flow
+
+We are now introducing a new unified message request flow that will replace all other request flows.
+
+Each request now consists of a single [Signed Message](../index.md) that is sent to the following endpoint:
+
+`https://id.uport.me/req/[JWT]`
+
+Se each specific flow for specifics on each message type.
+
 ## Specific Application flows
 
 - [Selective Disclosure Flow](selectivedisclosure.md)

--- a/flows/privatechain.md
+++ b/flows/privatechain.md
@@ -27,6 +27,10 @@ NOTE: We will provide a better way of provisioning a owner address in future ver
 
 The request should be sent to one of the following URLs:
 
+- `https://id.uport.me/req/[JWT]`
+
+*The following endpoints are deprecated*
+
 - `me.uport:net/[JWT]`
 - `https://id.uport.me/net/[JWT]`
 

--- a/flows/selectivedisclosure.md
+++ b/flows/selectivedisclosure.md
@@ -8,12 +8,26 @@ The following shows the basic flow:
 
 ## Endpoint
 
-The request should be sent to one of the following URLs:
+The request should be sent to the following URLs:
+
+- `https://id.uport.me/req/[JWT]`
+
+*The following endpoints are deprecated*
 
 - `me.uport:me`
 - `https://id.uport.me/me`
 
 ## Send Request
+
+Create a valid signed [Selective Disclosure Request](../messages/sharereq.md) and send it to the uPort mobile app.
+
+Signed example:
+
+`https://id.uport.me/req/eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJp...`
+
+The attributes `redirect_url` and `callback_type` can also be appended to the URL as encoded query parameters to specify how you want the response and control returned. For more details see [Messages](./index.md#json-web-token).
+
+### Deprecated Flows
 
 Create a valid signed or unsigned [Selective Disclosure Request](../messages/sharereq.md) and send it to the uPort mobile app.
 
@@ -22,6 +36,7 @@ Signed example:
 `me.uport:me?requestToken=eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJp...`
 
 The attributes `redirect_url` and `callback_type` can also be appended to the URL as encoded query parameters to specify how you want the response and control returned. For more details see [Messages](./index.md#json-web-token).
+
 
 Unsigned example:
 

--- a/flows/verification.md
+++ b/flows/verification.md
@@ -12,14 +12,26 @@ A more complete example of using this with a simple Identify Verification servic
 
 ## Endpoint
 
-The request should be sent to one of the following URLs:
+The request should be sent to the following URLs:
+
+- `https://id.uport.me/req/[JWT]`
+
+*The following endpoints are deprecated*
 
 - `me.uport:add`
 - `https://id.uport.me/add`
 
 ## Send Verifications
 
-Create one or more [Verified Claims](../messages/verification.md) and send it to the uPort mobile app in the `attestations` query parameter. Multiple verifications can be included by comma separating them.
+Create a [Verified Claims](../messages/verification.md) and attach it to the `https://id.uport.me/req/` url. Present this URL to the user and the app will open.
+
+Example:
+
+`https://id.uport.me/req/eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJp...`
+
+### Deprecated Flows
+
+A deprecated version adds it to the uPort mobile app in the `attestations` query parameter.
 
 Example:
 

--- a/flows/verificiationreq.md
+++ b/flows/verificiationreq.md
@@ -8,10 +8,9 @@ The following shows the basic flow:
 
 ## Endpoint
 
-The request should be formatted using one of the following URLs:
+The request should be sent to the following URLs:
 
-- `me.uport:req`
-- `https://id.uport.me/req`
+- `https://id.uport.me/req/[JWT]`
 
 ## Send Request
 
@@ -19,7 +18,7 @@ Create a valid signed [Verified Claim Request](../messages/verificationreq.md) a
 
 Signed example:
 
-`me.uport:req?m=eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJp...`
+`https://id.uport.me/req/eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJp...`
 
 
 ## Client Callback

--- a/messages/index.md
+++ b/messages/index.md
@@ -50,7 +50,7 @@ These options allow you to tell the client how you want to receive the response.
 
 Each uPort compatible JWT must be signed using an secp256k1 curve. The public key is resolved for the `iss` using the [uPort PKI](../pki/index.md).
 
-## Unsigned Requests
+## Unsigned Requests (Deprecated)
 
 Many apps that run 100% in the browser do not have a secure way of signing a request. Therefore we provide unsigned versions of certain requests.
 

--- a/messages/privatechain.md
+++ b/messages/privatechain.md
@@ -12,6 +12,7 @@ Name | Description | Required
 ---- | ----------- | --------
 [`iss`](https://tools.ietf.org/html/rfc7519#section-4.1.1) | The [MNID](https://github.com/uport-project/mnid) of the signing identity| yes
 [`aud`](https://tools.ietf.org/html/rfc7519#section-4.1.1) | The [MNID](https://github.com/uport-project/mnid) of the parent identity (the receiver of this account)| yes
+`type`| `chainProv` | yes
 [`sub`](https://tools.ietf.org/html/rfc7519#section-4.1.1) | The [MNID](https://github.com/uport-project/mnid) encoding of the [private chain account](https://github.com/uport-project/uport-identity/blob/develop/contracts/Proxy.sol)| yes
 [`iat`](https://tools.ietf.org/html/rfc7519#section-4.1.6) | The time of issuance | yes
 [`exp`](https://tools.ietf.org/html/rfc7519#section-4.1.4) | Expiration time of Verification | no

--- a/messages/sharereq.md
+++ b/messages/sharereq.md
@@ -23,7 +23,7 @@ Name | Description | Required
 
 The attributes `redirect_url` and `callback_type` can also be appended to the signed request as URL encoded query parameters outside of the signed payload. They are used to specify how you want the response and control returned. For more details see [Messages](./index.md#json-web-token).
 
-## Unsigned Requests
+## Unsigned Requests (Deprecated)
 
 To perform an unsigned selective disclosure request append the request parameters as URL encoded query parameters to one of the above endpoints and open it. Eg.:
 

--- a/messages/verification.md
+++ b/messages/verification.md
@@ -12,6 +12,7 @@ Name | Description | Required
 ---- | ----------- | --------
 [`iss`](https://tools.ietf.org/html/rfc7519#section-4.1.1) | The [MNID](https://github.com/uport-project/mnid) of the signing identity| yes
 [`sub`](https://tools.ietf.org/html/rfc7519#section-4.1.1) | The [MNID](https://github.com/uport-project/mnid) of the subject identity| yes
+`type`| The type of attestation | no
 [`iat`](https://tools.ietf.org/html/rfc7519#section-4.1.6) | The time of issuance | yes
 [`exp`](https://tools.ietf.org/html/rfc7519#section-4.1.4) | Expiration time of Verification | no
 `claim` | An object containing one or more claims about `sub` eg: `{"name":"Carol Crypteau"}` | yes


### PR DESCRIPTION
All roads from the standard leads to having a single URL accepting all message types.

To do this we need to first of all decide a url:

`https://id.uport.me/req`

We need to make sure all message types are identifiable some how through a type attribute.

We need to add a new message type for ethereum transactions in a separate PR.