### PR TITLE
Subject in Verified Claim Request should be optional

### DIFF
--- a/messages/verificationreq.md
+++ b/messages/verificationreq.md
@@ -18,8 +18,8 @@ The following additional attributes of the JWT are supported:
 Name | Description | Required
 ---- | ----------- | --------
 `type` | MUST have the value `verReq` | yes
-`sub` | The DID of the identity you want the user to sign the claims ABOUT | yes
 `unsignedClaim` | An unsigned claim that the user is requested to sign, this should exactly match the `claim` of the finished signed [Verified Claim](./verification.md). | yes
+`sub` | The DID of the identity you want the user to sign the claims ABOUT | no
 `aud` | The DID of the identity you want to sign the Verified Claim | no
 `callback` | Callback URL for returning the response to a request (may be deprecated in future) | no
 `rexp` | Requested expiry time in seconds | no


### PR DESCRIPTION
This PR makes `sub` field in the Verified Claim Request to be optional.

There will be situations when users will need to sign a claim that contains multiple subjects, or no subjects at all.

For example, let's say there is an app that lets you sign traffic accident statements. User is a witness of a traffic accident, and is being asked to sign this claim:

```js
{
  "type":"verReq",
  "iss":"did:uport:REQUESTING_APP_OR_USER",
  "unsignedClaim": {
    "trafficAccidentStatement": {
      "generalInfo": {
        "accidentDate": "2018-06-12 16:20:00",
        "address": {
          "street": "Main str. 123",
          "city": "Vilnius",
          "country": "LT",
        },
      },
      "vehicleA": {
        "liableForCausingDamage": true,
        "driver": {
          "did": "did:uport:2o4234234234",
          "name": "John",
          "surname": "Doe"
        },
        "vehicle": {
          "make": 'Toyota',
          "type": 'RAV4',
          "registrationNr": 'ABC123',
          "countryOfRegistration": 'LT',
        },
      },
      "vehicleB": {
        "liableForCausingDamage": false,
        "driver": {
          "did": "did:uport:2o9899889343",
          "name": "Jane",
          "surname": "Doe"
        },
        "vehicle": {
          "make": "Tesla",
          "type": "Model S",
          "registrationNr": "XYZ876",
          "countryOfRegistration": "LT",
        }
      }
    }
  },
  "callback":"https://example.com",
  "rexp": 123456789
}
```