### PR TITLE
Support for simple styling of requests

### DIFF
--- a/messages/index.md
+++ b/messages/index.md
@@ -44,6 +44,7 @@ Name | Description | Required
 `callback` | Callback URL for returning the response to a request | no
 `type` | Type of Message | no
 `boxPub` | 32 byte base64 encoded [`Curve25519`](http://nacl.cr.yp.to/box.html) public key | no
+`style` | IPFS Hash of [style document](/messages/styles.md) | no
 
 The following attributes can also be appended to the signed request as URL encoded query parameters outside of the signed payload.
 

--- a/messages/sharereq.md
+++ b/messages/sharereq.md
@@ -28,6 +28,7 @@ Name | Description | Required
 `verified` | The verified claims requested from a user. Array of claim types for self signed claims eg: `["name", "email"]` | no
 `permissions` | An array of permissions requested. Currently only supported is `notifications` | no
 `boxPub` | 32 byte base64 encoded [`Curve25519`](http://nacl.cr.yp.to/box.html) public key of requesting identity. Use to encrypt messages sent to callback URL| no
+`style` | IPFS Hash of [style document](/messages/styles.md) | no
 
 The attributes `redirect_url` and `callback_type` can also be appended to the signed request as URL encoded query parameters outside of the signed payload. They are used to specify how you want the response and control returned. For more details see [Messages](./index.md#json-web-token).
 

--- a/messages/shareresp.md
+++ b/messages/shareresp.md
@@ -29,3 +29,4 @@ Name | Description | Required
 `verified` | Array of requested verification JWTs | no
 `capabilities` | An array of JWT tokens giving client app the permissions requested. Currently a token allowing them to send push notifications | no
 `boxPub` | 32 byte base64 encoded [`Curve25519`](http://nacl.cr.yp.to/box.html) public key used for sending encrypted messages to user | no
+`style` | IPFS Hash of [style document](/messages/styles.md) | no

--- a/messages/styles.md
+++ b/messages/styles.md
@@ -1,0 +1,35 @@
+---
+title: "Message Style Document"
+category: "reference"
+type: "content"
+source: "https://github.com/uport-project/specs/blob/develop/messages/styles.md"
+---
+
+# Styling Requests
+
+As a developer you can provide simple styling in a Style Document hosted on IPFS.
+
+The Style document is a JSON document stored as an [IPLD Document](https://github.com/ipld/specs/blob/master/IPLD.md).
+
+## Contents
+
+The Style document itself is optional and all fields are optional.
+
+This is a example of a Style document for an app with extra public profile information:
+
+```js
+{
+  "profileImage":{"/":"/ipfs/QmSCnmXC91Arz2gj934Ce4DeR7d9fULWRepjzGMX6SSazB"},
+  "bannerImage":{"/":"/ipfs/QmSCnmXC91Arz2gj934Ce4DeR7d9fULWRepjzGMX6SSazB"},
+  "accentColor":"#f0c0a3"
+}
+```
+
+### Parameters
+
+Name | Description | Required
+---- | ----------- | --------
+`profileImage` | Avatar or logo as JPEG or PNG of requester on IPFS as a [merkle link](https://github.com/ipld/specs/blob/master/IPLD.md#what-is-a-merkle-link)| no
+`bannerImage` | Banner to e used on certain request cards as JPEG or PNG of requester on IPFS as a [merkle link](https://github.com/ipld/specs/blob/master/IPLD.md#what-is-a-merkle-link)| no
+`accentColor` | Hex color to be used in the request card | no
+

--- a/messages/tx.md
+++ b/messages/tx.md
@@ -43,6 +43,7 @@ Name | Description | Required
 `callback_type` | Valid values `post` or `redirect`. Determines if callback should be sent as a HTTP POST or open the link (`redirect`). If unspecified the mobile app will attempt to pick the correct one| no
 `client_id` | The [DID](https://w3c-ccg.github.io/did-spec) or [MNID](https://github.com/uport-project/mnid) of the requesting identity | no
 `label` | Plain text name of client to be displayed to user | no
+`style` | IPFS Hash of [style document](/messages/styles.md) | no
 `boxPub` | 32 byte base64 encoded [`Curve25519`](http://nacl.cr.yp.to/box.html) public key of requesting identity. Use to encrypt messages sent to callback URL| no
 
 The attributes `redirect_url` can also be appended to the signed request as URL encoded query parameters outside of the signed payload. They are used to specify how you want the response and control returned. For more details see [Messages](./index.md#json-web-token).

--- a/messages/verification.md
+++ b/messages/verification.md
@@ -24,6 +24,7 @@ Name | Description | Required
 [`iat`](https://tools.ietf.org/html/rfc7519#section-4.1.6) | The time of issuance | yes
 [`exp`](https://tools.ietf.org/html/rfc7519#section-4.1.4) | Expiration time of Verification | no
 `claim` | An object containing one or more claims about `sub` eg: `{"name":"Carol Crypteau"}` | yes
+`style` | IPFS Hash of [style document](/messages/styles.md) | no
 
 ## Claims Best Practices
 

--- a/messages/verificationreq.md
+++ b/messages/verificationreq.md
@@ -24,6 +24,7 @@ Name | Description | Required
 `aud` | The DID of the identity you want to sign the Verified Claim | no
 `callback` | Callback URL for returning the response to a request (may be deprecated in future) | no
 `rexp` | Requested expiry time in seconds | no
+`style` | IPFS Hash of [style document](/messages/styles.md) | no
 
 
 Example Verified Claim request:


### PR DESCRIPTION
As a developer I want to be able to present my apps branding in requests to a user.

We believe that Making it easier for developer to show profile information about app when making requests to user will Allow developers to build more “trust” in their app for a Developer

Branding builds trust by a requesting app to encourage a user to interact with them and maintain a relationship in the future.

Branding in the app is built by mapping a name, icon, color scheme etc to the request.