### PR TITLE
Allow issuers of Requests to include self signed and verified claims about themselves to build trust

### DIFF
--- a/messages/claims.md
+++ b/messages/claims.md
@@ -7,18 +7,28 @@ source: "https://github.com/uport-project/specs/blob/develop/messages/claims.md"
 
 # Issuer Claims
 
+The issuer of a message is the signer of the request. The issuer can present claims about themselves. This either as unverified claims made by them selves. Such as:
+
+`{"name":"Super Kitties", "url":'https://superkitties.example'}`
+
+This can be used over time to build trust between the issuer of the message and the consuming party.
+
+Another kind of claims are [verified claims](/messages/verification.md). The issuer can include one or more of these to help build trust in themselves.
+
+## Self Claims
+
 As the issuer of a request you can provide your own claims about who you are within your request. This is primarily for adding name and branding to a request.
 
 It is important to remember that this is not verified and consumers of the data such as the uPort mobile app will present it as unverified.
 
-## Embedded Format
+### Embedded Format
 
 These claims can be either be embedded as a json object as below:
 
 ```js
 {
   "iss":"did:ethr:0x012abcd...",
-  "own": {
+  "issc": {
     "name":"My dApp",
     "url":"https://mydapp.example",
     "profileImage":"/ipfs/QmV3pEPwSzkQVMPmkvpWRvWRxexdMrCNayMnZeao8dibm4",
@@ -38,7 +48,7 @@ Upload the image like this:
 
 Remember to prefix the hash with `/ipfs/`.
 
-## IPLD Format
+### IPLD Format
 
 To reduce the size of messages we remember storing the claims as an as an [IPLD Document](https://github.com/ipld/specs/blob/master/IPLD.md).
 QmbpLchVBiF5Deg8Dp31y4AUSNLiBbF92mHAp3xDcAfg4k
@@ -69,7 +79,7 @@ Now use the returned hash in your requests:
 ```js
 {
   "iss":"did:ethr:0x012abcd...",
-  "own": "ipfs/QmbpLchVBiF5Deg8Dp31y4AUSNLiBbF92mHAp3xDcAfg4k"
+  "issc": "/ipfs/QmbpLchVBiF5Deg8Dp31y4AUSNLiBbF92mHAp3xDcAfg4k"
 }
 ```
 
@@ -84,3 +94,25 @@ Name | Description | Required
 `url` | URL of dApp/Requester | no
 `profileImage` | Avatar or logo as JPEG or PNG of requester on IPFS as a `/ipfs/[HASH]` in embedded claims or a [merkle link](https://github.com/ipld/specs/blob/master/IPLD.md#what-is-a-merkle-link) for IPLD documents| no
 `bannerImage` | Banner to e used on certain request cards as JPEG or PNG of requester on IPFS as a `/ipfs/[HASH]` in embedded claims or a [merkle link](https://github.com/ipld/specs/blob/master/IPLD.md#what-is-a-merkle-link) for IPLD documents| no
+
+## Verified Claims about Issuer
+
+A selection of [verified claims](/messages/verification.md) about the issuer can be included in the `vc` field of a message. 
+
+The verified claims can either be included in their entirety as [JWT's](https://tools.ietf.org/html/rfc7519)'s in an array:
+
+```js
+{
+  "iss":"did:ethr:0x012abcd...",
+  "vc": ["Verified Claim JWT 1", "Verified Claim JWT 2"]
+}
+```
+
+Or as an array of IPFS hashes containing individual JWTs.
+
+```js
+{
+  "iss":"did:ethr:0x012abcd...",
+  "vc": ["/ipfs/QmbpLchVBiF5Deg8Dp31y4AUSNLiBbF92mHAp3xDcAfg4k"]
+}
+```

--- a/messages/claims.md
+++ b/messages/claims.md
@@ -17,7 +17,7 @@ Another kind of claims are [verified claims](/messages/verification.md). The iss
 
 ## Self Claims
 
-As the issuer of a request you can provide your own claims about who you are within your request. This is primarily for adding name and branding to a request.
+As the issuer of a request you can provide your own claims about who you are within your request. Include it as the `issc` of the message. This is primarily used for adding name and branding to a request.
 
 It is important to remember that this is not verified and consumers of the data such as the uPort mobile app will present it as unverified.
 

--- a/messages/claims.md
+++ b/messages/claims.md
@@ -1,0 +1,86 @@
+---
+title: "Issuer Claims"
+category: "reference"
+type: "content"
+source: "https://github.com/uport-project/specs/blob/develop/messages/claims.md"
+---
+
+# Issuer Claims
+
+As the issuer of a request you can provide your own claims about who you are within your request. This is primarily for adding name and branding to a request.
+
+It is important to remember that this is not verified and consumers of the data such as the uPort mobile app will present it as unverified.
+
+## Embedded Format
+
+These claims can be either be embedded as a json object as below:
+
+```js
+{
+  "iss":"did:ethr:0x012abcd...",
+  "own": {
+    "name":"My dApp",
+    "url":"https://mydapp.example",
+    "profileImage":"/ipfs/QmV3pEPwSzkQVMPmkvpWRvWRxexdMrCNayMnZeao8dibm4",
+    ...
+  }
+}
+```
+
+**About image links:** Images must be stored in IPFS. This is to avoid malicious tracking of users through images.
+
+Upload the image like this:
+
+```bash
+> curl  "https://ipfs.infura.io:5001/api/v0/add?pin=true" -F file=@logo.png
+{"Name":"logo.png","Hash":"QmV3pEPwSzkQVMPmkvpWRvWRxexdMrCNayMnZeao8dibm4","Size":"5779"}
+```
+
+Remember to prefix the hash with `/ipfs/`.
+
+## IPLD Format
+
+To reduce the size of messages we remember storing the claims as an as an [IPLD Document](https://github.com/ipld/specs/blob/master/IPLD.md).
+QmbpLchVBiF5Deg8Dp31y4AUSNLiBbF92mHAp3xDcAfg4k
+
+Upload your claims document to IPFS.
+
+Example document:
+
+```js
+{
+  "name":"My dApp",
+  "description":"A really cool place to do stuff decentralized",
+  "url":"https://mydapp.example",
+  "profileImage":{"/":"/ipfs/QmSCnmXC91Arz2gj934Ce4DeR7d9fULWRepjzGMX6SSazB"},
+  "bannerImage":{"/":"/ipfs/QmSCnmXC91Arz2gj934Ce4DeR7d9fULWRepjzGMX6SSazB"},
+}
+```
+
+Save the above file to `claims.json`
+
+```bash
+> curl  "https://ipfs.infura.io:5001/api/v0/add?pin=true" -F file=@claims.json
+{"Name":"claims.json","Hash":"QmbpLchVBiF5Deg8Dp31y4AUSNLiBbF92mHAp3xDcAfg4k","Size":"291"}
+```
+
+Now use the returned hash in your requests:
+
+```js
+{
+  "iss":"did:ethr:0x012abcd...",
+  "own": "ipfs/QmbpLchVBiF5Deg8Dp31y4AUSNLiBbF92mHAp3xDcAfg4k"
+}
+```
+
+**Note:** For links to other IPFS files such as images, you must add then as an [IPLD merkle link](https://github.com/ipld/specs/blob/master/IPLD.md#what-is-a-merkle-link). This just means that instead of using the string `ipfs/QmV3pEPwSzkQVMPmkvpWRvWRxexdMrCNayMnZeao8dibm4` as in an embedded document. You use the object `{"/":"/ipfs/QmV3pEPwSzkQVMPmkvpWRvWRxexdMrCNayMnZeao8dibm4"}` instead.
+
+### Parameters
+
+Name | Description | Required
+---- | ----------- | --------
+`name`| Name of Issuer | no
+`description`| Single sentence describing the Issuer | no
+`url` | URL of dApp/Requester | no
+`profileImage` | Avatar or logo as JPEG or PNG of requester on IPFS as a `/ipfs/[HASH]` in embedded claims or a [merkle link](https://github.com/ipld/specs/blob/master/IPLD.md#what-is-a-merkle-link) for IPLD documents| no
+`bannerImage` | Banner to e used on certain request cards as JPEG or PNG of requester on IPFS as a `/ipfs/[HASH]` in embedded claims or a [merkle link](https://github.com/ipld/specs/blob/master/IPLD.md#what-is-a-merkle-link) for IPLD documents| no

--- a/messages/index.md
+++ b/messages/index.md
@@ -43,8 +43,8 @@ Name | Description | Required
 ---- | ----------- | --------
 `callback` | Callback URL for returning the response to a request | no
 `type` | Type of Message | no
-`own` | The self signed claims for the `iss` of this message. Either as an Object of claim types for self signed claims eg: `{"name":"Some Corp Inc", "url":"https://somecorp.example","image":{"/":"/ipfs/QmSCnmXC91Arz2gj934Ce4DeR7d9fULWRepjzGMX6SSazB"}}` or the IPFS Hash of a JSON encoded equivalent. See [Issuer Claims](/messages/claims.md) | no
-`verified` | Array of Verified Claims JWTs or IPFS hash of JSON encoded equivalent about the `iss` of this message. See [Verified Claims](/messages/verification.md) | no
+`issc` | The self signed claims for the `iss` of this message. Either as an Object of claim types for self signed claims eg: `{"name":"Some Corp Inc", "url":"https://somecorp.example","image":{"/":"/ipfs/QmSCnmXC91Arz2gj934Ce4DeR7d9fULWRepjzGMX6SSazB"}}` or the IPFS Hash of a JSON encoded equivalent. See [Issuer Claims](/messages/claims.md) | no
+`vc` | Array of Verified Claims JWTs or IPFS hash of JSON encoded equivalent about the `iss` of this message. See [Issuer Claims](/messages/claims.md) and [Verified Claims](/messages/verification.md) | no
 `boxPub` | 32 byte base64 encoded [`Curve25519`](http://nacl.cr.yp.to/box.html) public key | no
 
 The following attributes can also be appended to the signed request as URL encoded query parameters outside of the signed payload.

--- a/messages/index.md
+++ b/messages/index.md
@@ -43,6 +43,8 @@ Name | Description | Required
 ---- | ----------- | --------
 `callback` | Callback URL for returning the response to a request | no
 `type` | Type of Message | no
+`own` | The self signed claims for the `iss` of this message. Either as an Object of claim types for self signed claims eg: `{"name":"Some Corp Inc", "url":"https://somecorp.example","image":{"/":"/ipfs/QmSCnmXC91Arz2gj934Ce4DeR7d9fULWRepjzGMX6SSazB"}}` or the IPFS Hash of a JSON encoded equivalent. See [Issuer Claims](/messages/claims.md) | no
+`verified` | Array of Verified Claims JWTs or IPFS hash of JSON encoded equivalent about the `iss` of this message. See [Verified Claims](/messages/verification.md) | no
 `boxPub` | 32 byte base64 encoded [`Curve25519`](http://nacl.cr.yp.to/box.html) public key | no
 
 The following attributes can also be appended to the signed request as URL encoded query parameters outside of the signed payload.

--- a/messages/privatechain.md
+++ b/messages/privatechain.md
@@ -29,3 +29,5 @@ Name | Description | Required
 `rel`|Url of [relay service](/rest-apis/relay-server.md) for providing gas on private network | no (recommended)
 `fct`|Url of [fueling service](/rest-apis/fuel-server.md) for providing gas on private network | no
 `acc`|Fuel token used to authenticate on above `fct` url | yes
+`own` | The self signed claims for the `iss` of this message. Either as an Object of claim types for self signed claims eg: `{"name":"Some Corp Inc", "url":"https://somecorp.example","image":{"/":"/ipfs/QmSCnmXC91Arz2gj934Ce4DeR7d9fULWRepjzGMX6SSazB"}}` or the IPFS Hash of a JSON encoded equivalent. See [Issuer Claims](/messages/claims.md) | no
+`verified` | Array of Verified Claims JWTs or IPFS hash of JSON encoded equivalent about the `iss` of this message. See [Verified Claims](/messages/verification.md) | no

--- a/messages/privatechain.md
+++ b/messages/privatechain.md
@@ -29,5 +29,5 @@ Name | Description | Required
 `rel`|Url of [relay service](/rest-apis/relay-server.md) for providing gas on private network | no (recommended)
 `fct`|Url of [fueling service](/rest-apis/fuel-server.md) for providing gas on private network | no
 `acc`|Fuel token used to authenticate on above `fct` url | yes
-`own` | The self signed claims for the `iss` of this message. Either as an Object of claim types for self signed claims eg: `{"name":"Some Corp Inc", "url":"https://somecorp.example","image":{"/":"/ipfs/QmSCnmXC91Arz2gj934Ce4DeR7d9fULWRepjzGMX6SSazB"}}` or the IPFS Hash of a JSON encoded equivalent. See [Issuer Claims](/messages/claims.md) | no
-`verified` | Array of Verified Claims JWTs or IPFS hash of JSON encoded equivalent about the `iss` of this message. See [Verified Claims](/messages/verification.md) | no
+`issc` | The self signed claims for the `iss` of this message. Either as an Object of claim types for self signed claims eg: `{"name":"Some Corp Inc", "url":"https://somecorp.example","image":{"/":"/ipfs/QmSCnmXC91Arz2gj934Ce4DeR7d9fULWRepjzGMX6SSazB"}}` or the IPFS Hash of a JSON encoded equivalent. See [Issuer Claims](/messages/claims.md) | no
+`vc` | Array of Verified Claims JWTs or IPFS hash of JSON encoded equivalent about the `iss` of this message. See [Issuer Claims](/messages/claims.md) and [Verified Claims](/messages/verification.md) | no

--- a/messages/sharereq.md
+++ b/messages/sharereq.md
@@ -28,8 +28,8 @@ Name | Description | Required
 `verified` | The verified claims requested from a user. Array of claim types for self signed claims eg: `["name", "email"]`, see [Verified Claims](/messages/verification.md) | no
 `permissions` | An array of permissions requested. Currently only supported is `notifications` | no
 `boxPub` | 32 byte base64 encoded [`Curve25519`](http://nacl.cr.yp.to/box.html) public key of requesting identity. Use to encrypt messages sent to callback URL| no
-`own` | The self signed claims for the `iss` of this message. Either as an Object of claim types for self signed claims eg: `{"name":"Some Corp Inc", "url":"https://somecorp.example","image":{"/":"/ipfs/QmSCnmXC91Arz2gj934Ce4DeR7d9fULWRepjzGMX6SSazB"}}` or the IPFS Hash of a JSON encoded equivalent. See [Issuer Claims](/messages/claims.md) | no
-`verified` | Array of Verified Claims JWTs or IPFS hash of JSON encoded equivalent about the `iss` of this message. See [Verified Claims](/messages/verification.md) | no
+`issc` | The self signed claims for the `iss` of this message. Either as an Object of claim types for self signed claims eg: `{"name":"Some Corp Inc", "url":"https://somecorp.example","image":{"/":"/ipfs/QmSCnmXC91Arz2gj934Ce4DeR7d9fULWRepjzGMX6SSazB"}}` or the IPFS Hash of a JSON encoded equivalent. See [Issuer Claims](/messages/claims.md) | no
+`vc` | Array of Verified Claims JWTs or IPFS hash of JSON encoded equivalent about the `iss` of this message. See [Issuer Claims](/messages/claims.md) and [Verified Claims](/messages/verification.md) | no
 
 The attributes `redirect_url` and `callback_type` can also be appended to the signed request as URL encoded query parameters outside of the signed payload. They are used to specify how you want the response and control returned. For more details see [Messages](./index.md#json-web-token).
 

--- a/messages/sharereq.md
+++ b/messages/sharereq.md
@@ -24,12 +24,17 @@ Name | Description | Required
 `callback` | Callback URL for returning the response to a request | no
 `net` | network id of Ethereum chain of identity eg. `0x4` for `rinkeby` | no
 `act` | Ethereum account type: `general` users choice (default), `segregated` a unique smart contract based account will be created for requesting app, `keypair` a unique keypair based account will be created for requesting app, `devicekey` request a new device key for a [Private Chain Account](./privatechain.md), `none` no account is returned | no
-`requested` | The self signed claims requested from a user. Array of claim types for self signed claims eg: `["name", "email"]` | no
-`verified` | The verified claims requested from a user. Array of claim types for self signed claims eg: `["name", "email"]` | no
+`requested` | The self signed claims requested from a user. Array of claim types for self signed claims. Currently supported: `["name", "email", "image", "country", "phone"]` | no
+`verified` | The verified claims requested from a user. Array of claim types for self signed claims eg: `["name", "email"]`, see [Verified Claims](/messages/verification.md) | no
 `permissions` | An array of permissions requested. Currently only supported is `notifications` | no
 `boxPub` | 32 byte base64 encoded [`Curve25519`](http://nacl.cr.yp.to/box.html) public key of requesting identity. Use to encrypt messages sent to callback URL| no
+`own` | The self signed claims for the `iss` of this message. Either as an Object of claim types for self signed claims eg: `{"name":"Some Corp Inc", "url":"https://somecorp.example","image":{"/":"/ipfs/QmSCnmXC91Arz2gj934Ce4DeR7d9fULWRepjzGMX6SSazB"}}` or the IPFS Hash of a JSON encoded equivalent. See [Issuer Claims](/messages/claims.md) | no
+`verified` | Array of Verified Claims JWTs or IPFS hash of JSON encoded equivalent about the `iss` of this message. See [Verified Claims](/messages/verification.md) | no
 
 The attributes `redirect_url` and `callback_type` can also be appended to the signed request as URL encoded query parameters outside of the signed payload. They are used to specify how you want the response and control returned. For more details see [Messages](./index.md#json-web-token).
+
+#### Claim Types
+
 
 ## Unsigned Requests (Deprecated)
 

--- a/messages/shareresp.md
+++ b/messages/shareresp.md
@@ -25,7 +25,7 @@ Name | Description | Required
 `req`| The original JWT encoded Selective Disclosure Request | yes for responses to signed requests
 `nad`| The [MNID](https://github.com/uport-project/mnid) of the Ethereum account requested using `act` in the [Selective Disclosure Request](sharereq.md) | no
 `dad`| The `devicekey` as a regular hex encoded ethereum address as requested using `act='devicekey'` in the [Selective Disclosure Request](sharereq.md) | no
-`own` | The self signed claims requested from a user. Object of claim types for self signed claims eg: `{"name":"Carol Crypteau", "email":"carol@sample.com"}` | no
-`verified` | Array of requested verification JWTs | no
+`own` | The self signed claims requested from a user. Either as an Object of claim types for self signed claims eg: `{"name":"Carol Crypteau", "email":"carol@sample.com","image":{"/":"/ipfs/QmSCnmXC91Arz2gj934Ce4DeR7d9fULWRepjzGMX6SSazB"}}` or the IPFS Hash of a JSON encoded equivalent. See [claims](/messages/claims.md) | no
+`verified` | Array of Verified Claims JWTs or IPFS hash of JSON encoded equivalent. See [Verified Claims](/messages/verification.md) | no
 `capabilities` | An array of JWT tokens giving client app the permissions requested. Currently a token allowing them to send push notifications | no
 `boxPub` | 32 byte base64 encoded [`Curve25519`](http://nacl.cr.yp.to/box.html) public key used for sending encrypted messages to user | no

--- a/messages/shareresp.md
+++ b/messages/shareresp.md
@@ -25,7 +25,7 @@ Name | Description | Required
 `req`| The original JWT encoded Selective Disclosure Request | yes for responses to signed requests
 `nad`| The [MNID](https://github.com/uport-project/mnid) of the Ethereum account requested using `act` in the [Selective Disclosure Request](sharereq.md) | no
 `dad`| The `devicekey` as a regular hex encoded ethereum address as requested using `act='devicekey'` in the [Selective Disclosure Request](sharereq.md) | no
-`own` | The self signed claims requested from a user. Either as an Object of claim types for self signed claims eg: `{"name":"Carol Crypteau", "email":"carol@sample.com","image":{"/":"/ipfs/QmSCnmXC91Arz2gj934Ce4DeR7d9fULWRepjzGMX6SSazB"}}` or the IPFS Hash of a JSON encoded equivalent. See [claims](/messages/claims.md) | no
-`verified` | Array of Verified Claims JWTs or IPFS hash of JSON encoded equivalent. See [Verified Claims](/messages/verification.md) | no
+`own|issc` | The self signed claims requested from a user. Either as an Object of claim types for self signed claims eg: `{"name":"Carol Crypteau", "email":"carol@sample.com","image":{"/":"/ipfs/QmSCnmXC91Arz2gj934Ce4DeR7d9fULWRepjzGMX6SSazB"}}` or the IPFS Hash of a JSON encoded equivalent. See [claims](/messages/claims.md) | no
+`verified|vc` | Array of Verified Claims JWTs or IPFS hash of JSON encoded equivalent. See [Verified Claims](/messages/verification.md) | no
 `capabilities` | An array of JWT tokens giving client app the permissions requested. Currently a token allowing them to send push notifications | no
 `boxPub` | 32 byte base64 encoded [`Curve25519`](http://nacl.cr.yp.to/box.html) public key used for sending encrypted messages to user | no

--- a/messages/tx.md
+++ b/messages/tx.md
@@ -44,6 +44,8 @@ Name | Description | Required
 `client_id` | The [DID](https://w3c-ccg.github.io/did-spec) or [MNID](https://github.com/uport-project/mnid) of the requesting identity | no
 `label` | Plain text name of client to be displayed to user | no
 `boxPub` | 32 byte base64 encoded [`Curve25519`](http://nacl.cr.yp.to/box.html) public key of requesting identity. Use to encrypt messages sent to callback URL| no
+`own` | The self signed claims for the `iss` of this message. Either as an Object of claim types for self signed claims eg: `{"name":"Some Corp Inc", "url":"https://somecorp.example","image":{"/":"/ipfs/QmSCnmXC91Arz2gj934Ce4DeR7d9fULWRepjzGMX6SSazB"}}` or the IPFS Hash of a JSON encoded equivalent. See [Issuer Claims](/messages/claims.md) | no
+`verified` | Array of Verified Claims JWTs or IPFS hash of JSON encoded equivalent about the `iss` of this message. See [Verified Claims](/messages/verification.md) | no
 
 The attributes `redirect_url` can also be appended to the signed request as URL encoded query parameters outside of the signed payload. They are used to specify how you want the response and control returned. For more details see [Messages](./index.md#json-web-token).
 

--- a/messages/tx.md
+++ b/messages/tx.md
@@ -44,8 +44,8 @@ Name | Description | Required
 `client_id` | The [DID](https://w3c-ccg.github.io/did-spec) or [MNID](https://github.com/uport-project/mnid) of the requesting identity | no
 `label` | Plain text name of client to be displayed to user | no
 `boxPub` | 32 byte base64 encoded [`Curve25519`](http://nacl.cr.yp.to/box.html) public key of requesting identity. Use to encrypt messages sent to callback URL| no
-`own` | The self signed claims for the `iss` of this message. Either as an Object of claim types for self signed claims eg: `{"name":"Some Corp Inc", "url":"https://somecorp.example","image":{"/":"/ipfs/QmSCnmXC91Arz2gj934Ce4DeR7d9fULWRepjzGMX6SSazB"}}` or the IPFS Hash of a JSON encoded equivalent. See [Issuer Claims](/messages/claims.md) | no
-`verified` | Array of Verified Claims JWTs or IPFS hash of JSON encoded equivalent about the `iss` of this message. See [Verified Claims](/messages/verification.md) | no
+`issc` | The self signed claims for the `iss` of this message. Either as an Object of claim types for self signed claims eg: `{"name":"Some Corp Inc", "url":"https://somecorp.example","image":{"/":"/ipfs/QmSCnmXC91Arz2gj934Ce4DeR7d9fULWRepjzGMX6SSazB"}}` or the IPFS Hash of a JSON encoded equivalent. See [Issuer Claims](/messages/claims.md) | no
+`vc` | Array of Verified Claims JWTs or IPFS hash of JSON encoded equivalent about the `iss` of this message. See [Issuer Claims](/messages/claims.md) and [Verified Claims](/messages/verification.md) | no
 
 The attributes `redirect_url` can also be appended to the signed request as URL encoded query parameters outside of the signed payload. They are used to specify how you want the response and control returned. For more details see [Messages](./index.md#json-web-token).
 

--- a/messages/verification.md
+++ b/messages/verification.md
@@ -1,12 +1,12 @@
 ---
-title: "Verification"
+title: "Verified Claims"
 category: "reference"
 type: "content"
 source: "https://github.com/uport-project/specs/blob/develop/messages/verification.md"
 ---
 
 
-# Verification
+# Verified Claims
 
 A Verified Claim is a statement issued by a third party verifying claims about an identity [Verified Claim Flow](../flows/verification.md).
 
@@ -24,6 +24,8 @@ Name | Description | Required
 [`iat`](https://tools.ietf.org/html/rfc7519#section-4.1.6) | The time of issuance | yes
 [`exp`](https://tools.ietf.org/html/rfc7519#section-4.1.4) | Expiration time of Verification | no
 `claim` | An object containing one or more claims about `sub` eg: `{"name":"Carol Crypteau"}` | yes
+`own` | The self signed claims for the `iss` of this verified claim. Either as an Object of claim types for self signed claims eg: `{"name":"Some Corp Inc", "url":"https://somecorp.example","image":{"/":"/ipfs/QmSCnmXC91Arz2gj934Ce4DeR7d9fULWRepjzGMX6SSazB"}}` or the IPFS Hash of a JSON encoded equivalent. See [Issuer Claims](/messages/claims.md) | no
+`verified` | Array of Verified Claims JWTs or IPFS hash of JSON encoded equivalent about the `iss` of this verified claim. | no
 
 ## Claims Best Practices
 

--- a/messages/verification.md
+++ b/messages/verification.md
@@ -24,8 +24,8 @@ Name | Description | Required
 [`iat`](https://tools.ietf.org/html/rfc7519#section-4.1.6) | The time of issuance | yes
 [`exp`](https://tools.ietf.org/html/rfc7519#section-4.1.4) | Expiration time of Verification | no
 `claim` | An object containing one or more claims about `sub` eg: `{"name":"Carol Crypteau"}` | yes
-`own` | The self signed claims for the `iss` of this verified claim. Either as an Object of claim types for self signed claims eg: `{"name":"Some Corp Inc", "url":"https://somecorp.example","image":{"/":"/ipfs/QmSCnmXC91Arz2gj934Ce4DeR7d9fULWRepjzGMX6SSazB"}}` or the IPFS Hash of a JSON encoded equivalent. See [Issuer Claims](/messages/claims.md) | no
-`verified` | Array of Verified Claims JWTs or IPFS hash of JSON encoded equivalent about the `iss` of this verified claim. | no
+`issc` | The self signed claims for the `iss` of this message. Either as an Object of claim types for self signed claims eg: `{"name":"Some Corp Inc", "url":"https://somecorp.example","image":{"/":"/ipfs/QmSCnmXC91Arz2gj934Ce4DeR7d9fULWRepjzGMX6SSazB"}}` or the IPFS Hash of a JSON encoded equivalent. See [Issuer Claims](/messages/claims.md) | no
+`vc` | Array of Verified Claims JWTs or IPFS hash of JSON encoded equivalent about the `iss` of this message | no
 
 ## Claims Best Practices
 

--- a/messages/verificationreq.md
+++ b/messages/verificationreq.md
@@ -18,12 +18,19 @@ The following additional attributes of the JWT are supported:
 
 Name | Description | Required
 ---- | ----------- | --------
+[`iss`](https://tools.ietf.org/html/rfc7519#section-4.1.1) | The [MNID](https://github.com/uport-project/mnid) of the signing identity| yes
+[`sub`](https://tools.ietf.org/html/rfc7519#section-4.1.2) | The [MNID](https://github.com/uport-project/mnid) of the subject of the JWT| no
+[`aud`](https://tools.ietf.org/html/rfc7519#section-4.1.3) | The [MNID](https://github.com/uport-project/mnid) or URL of the audience of the JWT. Our libraries or app will not accept any JWT that has someone else as the audience| no
+[`iat`](https://tools.ietf.org/html/rfc7519#section-4.1.6) | The time of issuance | yes
+[`exp`](https://tools.ietf.org/html/rfc7519#section-4.1.4) | Expiration time of JWT | no
 `type` | MUST have the value `verReq` | yes
 `unsignedClaim` | An unsigned claim that the user is requested to sign, this should exactly match the `claim` of the finished signed [Verified Claim](./verification.md). | yes
 `sub` | The DID of the identity you want the user to sign the claims ABOUT | no
 `aud` | The DID of the identity you want to sign the Verified Claim | no
 `callback` | Callback URL for returning the response to a request (may be deprecated in future) | no
 `rexp` | Requested expiry time in seconds | no
+`own` | The self signed claims for the `iss` of this message. Either as an Object of claim types for self signed claims eg: `{"name":"Some Corp Inc", "url":"https://somecorp.example","image":{"/":"/ipfs/QmSCnmXC91Arz2gj934Ce4DeR7d9fULWRepjzGMX6SSazB"}}` or the IPFS Hash of a JSON encoded equivalent. See [Issuer Claims](/messages/claims.md) | no
+`verified` | Array of Verified Claims JWTs or IPFS hash of JSON encoded equivalent about the `iss` of this message. See [Verified Claims](/messages/verification.md) | no
 
 
 Example Verified Claim request:

--- a/messages/verificationreq.md
+++ b/messages/verificationreq.md
@@ -29,8 +29,8 @@ Name | Description | Required
 `aud` | The DID of the identity you want to sign the Verified Claim | no
 `callback` | Callback URL for returning the response to a request (may be deprecated in future) | no
 `rexp` | Requested expiry time in seconds | no
-`own` | The self signed claims for the `iss` of this message. Either as an Object of claim types for self signed claims eg: `{"name":"Some Corp Inc", "url":"https://somecorp.example","image":{"/":"/ipfs/QmSCnmXC91Arz2gj934Ce4DeR7d9fULWRepjzGMX6SSazB"}}` or the IPFS Hash of a JSON encoded equivalent. See [Issuer Claims](/messages/claims.md) | no
-`verified` | Array of Verified Claims JWTs or IPFS hash of JSON encoded equivalent about the `iss` of this message. See [Verified Claims](/messages/verification.md) | no
+`issc` | The self signed claims for the `iss` of this message. Either as an Object of claim types for self signed claims eg: `{"name":"Some Corp Inc", "url":"https://somecorp.example","image":{"/":"/ipfs/QmSCnmXC91Arz2gj934Ce4DeR7d9fULWRepjzGMX6SSazB"}}` or the IPFS Hash of a JSON encoded equivalent. See [Issuer Claims](/messages/claims.md) | no
+`vc` | Array of Verified Claims JWTs or IPFS hash of JSON encoded equivalent about the `iss` of this message. See [Issuer Claims](/messages/claims.md) and [Verified Claims](/messages/verification.md) | no
 
 
 Example Verified Claim request:


### PR DESCRIPTION
This adds 2 new optional fields to all uPort JWT:

- `own` - The self signed claims for the `iss` of this message. Either as an Object of claim types for self signed claims eg: `{"name":"Some Corp Inc", "url":"https://somecorp.example","image":{"/":"/ipfs/QmSCnmXC91Arz2gj934Ce4DeR7d9fULWRepjzGMX6SSazB"}}` or the IPFS Hash of a JSON encoded equivalent
- `verified` - Array of Verified Claims JWTs or IPFS hash of JSON encoded equivalent about the `iss` of this message
