### PR TITLE
add simple way of marking attestations and requests as being 'dev' mode

### DIFF
--- a/messages/sharereq.md
+++ b/messages/sharereq.md
@@ -25,7 +25,8 @@ Name | Description | Required
 `net` | network id of Ethereum chain of identity eg. `0x4` for `rinkeby` | no
 `act` | Ethereum account type: `general` users choice (default), `segregated` a unique smart contract based account will be created for requesting app, `keypair` a unique keypair based account will be created for requesting app, `devicekey` request a new device key for a [Private Chain Account](./privatechain.md), `none` no account is returned | no
 `requested` | The self signed claims requested from a user. Array of claim types for self signed claims. Currently supported: `["name", "email", "image", "country", "phone"]` | no
-`verified` | The verified claims requested from a user. Array of claim types or [Claims Specs](#claims-spec) for self signed claims eg: `["name", {type: "email", essential: true, iss: [{did: 'did:web:uport.claims'}]}]`, see [Verified Claims](/messages/verification.md) | no
+`verified` | The verified claims requested from a user. Array of claim types for self signed claims eg: `["name", "email"]`, see [Verified Claims](/messages/verification.md) | no
+`dev` | `true` or `false`. Request verifications marked as being for developer use only. | no (defaults to `false`)
 `permissions` | An array of permissions requested. Currently only supported is `notifications` | no
 `boxPub` | 32 byte base64 encoded [`Curve25519`](http://nacl.cr.yp.to/box.html) public key of requesting identity. Use to encrypt messages sent to callback URL| no
 `issc` | The self signed claims for the `iss` of this message. Either as an Object of claim types for self signed claims eg: `{"name":"Some Corp Inc", "url":"https://somecorp.example","image":{"/":"/ipfs/QmSCnmXC91Arz2gj934Ce4DeR7d9fULWRepjzGMX6SSazB"}}` or the IPFS Hash of a JSON encoded equivalent. See [Issuer Claims](/messages/claims.md) | no

--- a/messages/verification.md
+++ b/messages/verification.md
@@ -26,6 +26,7 @@ Name | Description | Required
 `claim` | An object containing one or more claims about `sub` eg: `{"name":"Carol Crypteau"}` | yes
 `issc` | The self signed claims for the `iss` of this message. Either as an Object of claim types for self signed claims eg: `{"name":"Some Corp Inc", "url":"https://somecorp.example","image":{"/":"/ipfs/QmSCnmXC91Arz2gj934Ce4DeR7d9fULWRepjzGMX6SSazB"}}` or the IPFS Hash of a JSON encoded equivalent. See [Issuer Claims](/messages/claims.md) | no
 `vc` | Array of Verified Claims JWTs or IPFS hash of JSON encoded equivalent about the `iss` of this message | no
+`dev` | `true` or `false`. Is this Verification for development purpose only? Use it to distinguish between verifications created during development and/or testing. | no (defaults to `false`)
 
 ## Claims Best Practices
 

--- a/messages/verificationreq.md
+++ b/messages/verificationreq.md
@@ -30,6 +30,7 @@ Name | Description | Required
 `rexp` | Requested expiry time in seconds | no
 `issc` | The self signed claims for the `iss` of this message. Either as an Object of claim types for self signed claims eg: `{"name":"Some Corp Inc", "url":"https://somecorp.example","image":{"/":"/ipfs/QmSCnmXC91Arz2gj934Ce4DeR7d9fULWRepjzGMX6SSazB"}}` or the IPFS Hash of a JSON encoded equivalent. See [Issuer Claims](/messages/claims.md) | no
 `vc` | Array of Verified Claims JWTs or IPFS hash of JSON encoded equivalent about the `iss` of this message. See [Issuer Claims](/messages/claims.md) and [Verified Claims](/messages/verification.md) | no
+`dev` | `true` or `false`. Is this Verification for development purpose only? Use it to distinguish between verifications created during development and/or testing. | no (defaults to `false`)
 
 
 Example Verified Claim request:


### PR DESCRIPTION
We would like a way to differentiate between attestations issued during development and testing as well as real production attestations.

This adds a simple `"dev":true` parameter to attestations. For `sharereq` you can similarly specify `"dev":true` which allows the mobile app to return attestations marked  as dev. If not specified, no dev attestations should be returned.

I'm not crazy about the API. Please provide me with more feedback on this.