### PR TITLE
Fixed verReq spec

### DIFF
--- a/messages/verificationreq.md
+++ b/messages/verificationreq.md
@@ -28,7 +28,6 @@ Name | Description | Required
 `callback` | Callback URL for returning the response to a request (may be deprecated in future) | no
 `riss` | The DID of the identity you want to sign the Verified Claim | no
 `rexp` | Requested expiry time in seconds | no
-QmSCnmXC91Arz2gj934Ce4DeR7d9fULWRepjzGMX6SSazB"}}` or the IPFS Hash of a JSON encoded equivalent. See [Issuer Claims](/messages/claims.md) | no
 `vc` | Array of Verified Claims JWTs or IPFS hash of JSON encoded equivalent about the `iss` of this message. See [Issuer Claims](/messages/claims.md) and [Verified Claims](/messages/verification.md) | no
 
 


### PR DESCRIPTION
This somehow slipped while removing `riss` field